### PR TITLE
Fix wrong exponent of pow in eval_force

### DIFF
--- a/misc/model.cpp
+++ b/misc/model.cpp
@@ -13,13 +13,11 @@ array<double, 3> eval_force(const double * r1, double m1, const double * r2, dou
     double norm = 0;
     for(int c = 0; c < 3; c++){
         norm += pow(r1[c] - r2[c], 2);
-
     }
     
-
     for(int c = 0; c < 3; c++){
         f[c] = M * (r1[c] - r2[c]);
-        f[c] /= pow(norm, 3/2);
+        f[c] /= pow(norm, 3.0 / 2.0);
     }
     return f;
 }


### PR DESCRIPTION
In C/C++, expression `3 / 2` just eval to value `1`.
It is a fatal mistake which makes simulations totally wrong.